### PR TITLE
First shot at implementation for pragma handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 .vstags
 *.tar.gz
 Perl-Critic-Policy-RegularExpressions-RequireDefault-*/
+*.bak

--- a/Changes
+++ b/Changes
@@ -1,6 +1,5 @@
 Changelog for Perl-Critic-Policy-RegularExpressions-RequireDefault
 
-
 0.02 2018-11-26T07:43:46Z Maintenance release, update not required
 
 - Mention of requirement for Perl 5.14 as described in issue #3

--- a/README.md
+++ b/README.md
@@ -12,6 +12,11 @@ This policy has no affiliation
 
 # DESCRIPTION
 
+This poliy aims to help enforce using Perl's protective measures against security vulnerabilities related to Unicode, such as:
+
+- Visual Spoofing
+- Character and String Transformation Vulnerabilities
+
 The `/a` and `/aa` modifiers standing for ASCII-restrict or ASCII-safe, provides protection for applications that do not need to be exposed to all of Unicode and possible security issues with Unicode.
 
 `/a` causes the sequences `\d`, `\s`, `\w`, and the Posix character classes to match only in the ASCII range. Meaning:
@@ -77,8 +82,11 @@ Please see the listing in the file: `cpanfile`, included with the distribution f
 # SEE ALSO
 
 - [Perl regular expression documentation: perlre](https://perldoc.perl.org/perlre.html)
-- [Perl::Critic::Policy::RegularExpressions::RequireExtendedFormatting](https://metacpan.org/pod/Perl::Critic::Policy::RegularExpressions::RequireExtendedFormatting)
+- [Perl delta file describing introduction of modifiers in Perl 5.14](https://perldoc.pl/perl5140delta#%2Fd%2C-%2Fl%2C-%2Fu%2C-and-%2Fa-modifiers)
+- [Unicode Security Issues FAQ](http://www.unicode.org/faq/security.html)
 - [Unicode Security Guide](http://websec.github.io/unicode-security-guide/)
+- [Perl::Critic](https://metacpan.org/pod/Perl::Critic)
+- [Perl::Critic::Policy::RegularExpressions::RequireExtendedFormatting](https://metacpan.org/pod/Perl::Critic::Policy::RegularExpressions::RequireExtendedFormatting)
 
 # MOTIVATION
 

--- a/lib/Perl/Critic/Policy/RegularExpressions/RequireDefault.pm
+++ b/lib/Perl/Critic/Policy/RegularExpressions/RequireDefault.pm
@@ -9,7 +9,7 @@ use Perl::Critic::Utils qw{ :severities };
 
 use base 'Perl::Critic::Policy';
 
-our $VERSION = '0.02';
+our $VERSION = '1.00';
 
 #-----------------------------------------------------------------------------
 
@@ -88,7 +88,7 @@ Perl::Critic::Policy::RegularExpressions::RequireDefault - Always use the C</a> 
 
 =head1 VERSION
 
-This documentation describes version 0.02
+This documentation describes version 1.00
 
 =head1 AFFILIATION
 

--- a/lib/Perl/Critic/Policy/RegularExpressions/RequireDefault.pm
+++ b/lib/Perl/Critic/Policy/RegularExpressions/RequireDefault.pm
@@ -106,9 +106,7 @@ This poliy aims to help enforce using Perl's protective measures against securit
 
 =back
 
-
 The C</a> and C</aa> modifiers standing for ASCII-restrict or ASCII-safe, provides protection for applications that do not need to be exposed to all of Unicode and possible security issues with Unicode.
-
 
 C</a> causes the sequences C<\d>, C<\s>, C<\w>, and the Posix character classes to match only in the ASCII range. Meaning:
 
@@ -134,6 +132,19 @@ C</a> causes the sequences C<\d>, C<\s>, C<\w>, and the Posix character classes 
 
 =back
 
+The policy also supports the pragma:
+
+    use re 'a';
+
+and:
+
+    use re 'aa';
+
+Which mean it will not evaluate the regular expressions any further:
+
+    use re 'a';
+    my $letters =~ m/[A-Za-z0-9_]*/;   # ok
+
 Do note that the C</a> and C</aa> modifiers require Perl 5.14, so by using the recommended modifiers you indirectly introduct a requirement for Perl 5.14.
 
 This policy is inspired by L<Perl::Critic::Policy::RegularExpressions::RequireExtendedFormatting|https://metacpan.org/pod/Perl::Critic::Policy::RegularExpressions::RequireExtendedFormatting> and many implementation details was lifted from this particular distribution.
@@ -148,7 +159,15 @@ This distribution holds no known incompatibilities at this time, please see L</D
 
 =head1 BUGS AND LIMITATIONS
 
-This distribution holds no known incompatibilities at this time, please refer to the L<the issue listing on GitHub|https://github.com/jonasbn/perl-critic-policy-regularexpressions-requiredefault/issues> for more up to date information.
+=over
+
+=item * The pragma handling does not take into consideration of a pragma is disabled.
+
+=item * The pragma handling does not take lexical scope into consideration properly and only detects the definition once
+
+=back
+
+This distribution holds no other known limitations or bugs at this time, please refer to the L<the issue listing on GitHub|https://github.com/jonasbn/perl-critic-policy-regularexpressions-requiredefault/issues> for more up to date information.
 
 =head1 BUG REPORTING
 
@@ -179,6 +198,8 @@ This distribution requires:
 Please see the listing in the file: F<cpanfile>, included with the distribution for a complete listing and description for configuration, test and development.
 
 =head1 TODO
+
+Ideas and suggestions for improvements and new features are listed in GitHub and are marked as C<enhancement>.
 
 =over
 

--- a/t/test.t
+++ b/t/test.t
@@ -1,6 +1,8 @@
 use strict;
 use warnings;
 use Test::More qw(no_plan);
+use Env qw($TEST_VERBOSE);
+use Data::Dumper;
 
 use_ok 'Perl::Critic::Policy::RegularExpressions::RequireDefault';
 
@@ -29,6 +31,33 @@ foreach my $data (
         is( $_->description, $assertion, "violation: $assertion" );
     }
     is( scalar @violations, $want_count, "statement: $str" );
+}
+
+{
+    my $str = q[
+        use re '/a';
+        my $digits = 1234;
+        if ($digits =~ m/\d/) {
+            print "We have digits\n";
+        }
+    ];
+
+    my @violations = $critic->critique( \$str );
+
+    is( scalar @violations, 0 );
+}
+
+{
+    my $str = q[
+        use re '/aa';
+        my $greeting = 'hello world';
+
+        my $greeting =~ s/hello/goodmorning/;
+    ];
+
+    my @violations = $critic->critique( \$str );
+
+    is( scalar @violations, 0 );
 }
 
 exit 0;


### PR DESCRIPTION
This branch/PR addresses issue #2 

It does currently not handle all scenarios, but it is a beginning - my concern is the nature of the lexical scope and [PPI](https://metacpan.org/pod/PPI) and [Perl::Critic](http://perlcritic.com/)'s handling of this.

I would love for this to be extended with a configuration parameter `strict`, which enforces `aa` over just `a`, a separate issue will be created for this.